### PR TITLE
Ensure ".jar" is included in command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 > This is not a plugin
 
 ### How to run it
-Either copy the jar in your plugin directory and run it with `java -jar FindPacketevents-1.0-SNAPSHOT`
+Either copy the jar in your plugin directory and run it with `java -jar FindPacketevents-1.0-SNAPSHOT.jar`
 
-Or run it anywhere and provide the path to your plugin directory `java -jar FindPacketevents-1.0-SNAPSHOT mySuperPath`
+Or run it anywhere and provide the path to your plugin directory `java -jar FindPacketevents-1.0-SNAPSHOT.jar mySuperPath`
 
 Use at your own risk!


### PR DESCRIPTION
This resolves a small issue where people would forget to include `.jar` at the end of the file name and cause java to spit out the `Unable to access jarfile (file_name)` text.